### PR TITLE
refactor: replace direct api calls with custom hooks for data fetching

### DIFF
--- a/src/contexts/authContext.tsx
+++ b/src/contexts/authContext.tsx
@@ -1,8 +1,8 @@
-import useUser from "@/hooks/useUser";
 import { createContext, type ReactNode } from "react";
 import { AbilityBuilder, PureAbility } from "@casl/ability";
 import type { Permission } from "@/types/RoleType";
 import type { User } from "@/types/UserType";
+import { useMe } from "@/hooks/useUsers";
 
 type AuthContextType = {
   user: User | null;
@@ -17,7 +17,7 @@ export const AuthContext = createContext<AuthContextType | undefined>(
 );
 
 export const AuthContextProvider = ({ children }: { children: ReactNode }) => {
-  const { data: user, isLoading, error } = useUser();
+  const { data: user, isLoading, error } = useMe();
 
   const ability = new PureAbility(
     user?.role.permissions?.map((p: Permission) => ({

--- a/src/hooks/useCategories.tsx
+++ b/src/hooks/useCategories.tsx
@@ -1,0 +1,9 @@
+import { useQuery } from "@tanstack/react-query";
+import { getCategories } from "@/api/categories";
+
+export const useCategories = () => {
+  return useQuery({
+    queryKey: ["categories"],
+    queryFn: getCategories,
+  });
+};

--- a/src/hooks/useDoctors.tsx
+++ b/src/hooks/useDoctors.tsx
@@ -1,0 +1,9 @@
+import { useQuery } from "@tanstack/react-query";
+import { getDoctors } from "@/api/doctors";
+
+export const useDoctors = () => {
+  return useQuery({
+    queryKey: ["doctors"],
+    queryFn: getDoctors,
+  });
+};

--- a/src/hooks/useExpenses.tsx
+++ b/src/hooks/useExpenses.tsx
@@ -1,0 +1,9 @@
+import { useQuery } from "@tanstack/react-query";
+import { getExpenses } from "@/api/expenses";
+
+export const useExpenses = () => {
+  return useQuery({
+    queryKey: ["expenses"],
+    queryFn: getExpenses,
+  });
+};

--- a/src/hooks/useInvoices.tsx
+++ b/src/hooks/useInvoices.tsx
@@ -1,0 +1,23 @@
+import { useQuery } from "@tanstack/react-query";
+import { getInvoices, getInvoiceById } from "@/api/invoice";
+
+export const useInvoices = (
+  pageIndex: number = 0,
+  pageSize: number = 15,
+  search: string = "",
+  startDate?: string,
+  endDate?: string
+) => {
+  return useQuery({
+    queryKey: ["invoices", pageIndex, pageSize, search, startDate, endDate],
+    queryFn: () => getInvoices(pageIndex, pageSize, search, startDate, endDate),
+  });
+};
+
+export const useInvoice = (id: number | string | undefined) => {
+  return useQuery({
+    queryKey: ["invoice", id],
+    queryFn: () => getInvoiceById(Number(id)),
+    enabled: Boolean(id),
+  });
+};

--- a/src/hooks/useItems.tsx
+++ b/src/hooks/useItems.tsx
@@ -1,0 +1,22 @@
+import { useQuery } from "@tanstack/react-query";
+import { getItems, getItemById } from "@/api/inventories";
+
+export const useItems = (
+  pageIndex: number = 0,
+  pageSize: number = 15,
+  search: string = "",
+  filter: string = "__all"
+) => {
+  return useQuery({
+    queryKey: ["items", pageIndex, pageSize, search, filter],
+    queryFn: () => getItems(pageIndex, pageSize, search, filter),
+  });
+};
+
+export const useItem = (id: number | string | undefined) => {
+  return useQuery({
+    queryKey: ["item", id],
+    queryFn: () => getItemById(Number(id)),
+    enabled: Boolean(id),
+  });
+};

--- a/src/hooks/useLocations.tsx
+++ b/src/hooks/useLocations.tsx
@@ -1,0 +1,9 @@
+import { useQuery } from "@tanstack/react-query";
+import { getLocations } from "@/api/locations";
+
+export const useLocations = () => {
+  return useQuery({
+    queryKey: ["locations"],
+    queryFn: getLocations,
+  });
+};

--- a/src/hooks/usePatients.tsx
+++ b/src/hooks/usePatients.tsx
@@ -1,0 +1,17 @@
+import { useQuery } from "@tanstack/react-query";
+import { getPatients, getPatientById } from "@/api/patients";
+
+export const usePatients = () => {
+  return useQuery({
+    queryKey: ["patients"],
+    queryFn: getPatients,
+  });
+};
+
+export const usePatient = (id: number | string | undefined) => {
+  return useQuery({
+    queryKey: ["patient", id],
+    queryFn: () => getPatientById(Number(id)),
+    enabled: Boolean(id),
+  });
+};

--- a/src/hooks/useRoles.tsx
+++ b/src/hooks/useRoles.tsx
@@ -1,0 +1,25 @@
+import { useQuery } from "@tanstack/react-query";
+import { getRoles, getRoleById } from "@/api/roles";
+import { getPermissions } from "@/api/permissions";
+
+export const useRoles = () => {
+  return useQuery({
+    queryKey: ["roles"],
+    queryFn: getRoles,
+  });
+};
+
+export const useRole = (id: number | string | undefined) => {
+  return useQuery({
+    queryKey: ["role", id],
+    queryFn: () => getRoleById(Number(id)),
+    enabled: Boolean(id),
+  });
+};
+
+export const usePermissions = () => {
+  return useQuery({
+    queryKey: ["permissions"],
+    queryFn: getPermissions,
+  });
+};

--- a/src/hooks/useServices.tsx
+++ b/src/hooks/useServices.tsx
@@ -1,0 +1,9 @@
+import { useQuery } from "@tanstack/react-query";
+import { getServices } from "@/api/services";
+
+export const useServices = () => {
+  return useQuery({
+    queryKey: ["services"],
+    queryFn: getServices,
+  });
+};

--- a/src/hooks/useTreatments.tsx
+++ b/src/hooks/useTreatments.tsx
@@ -1,0 +1,23 @@
+import { useQuery } from "@tanstack/react-query";
+import { getTreatments, getTreatmentById } from "@/api/treatments";
+
+export const useTreatments = (
+  pageIndex: number = 0,
+  pageSize: number = 15,
+  search: string = "",
+  startDate?: string,
+  endDate?: string
+) => {
+  return useQuery({
+    queryKey: ["treatments", pageIndex, pageSize, search, startDate, endDate],
+    queryFn: () => getTreatments(pageIndex, pageSize, search, startDate, endDate),
+  });
+};
+
+export const useTreatment = (id: number | string | undefined) => {
+  return useQuery({
+    queryKey: ["treatment", id],
+    queryFn: () => getTreatmentById(Number(id)),
+    enabled: Boolean(id),
+  });
+};

--- a/src/hooks/useUser.tsx
+++ b/src/hooks/useUser.tsx
@@ -1,6 +1,7 @@
 import { getMe } from "@/api/users";
 import { useQuery } from "@tanstack/react-query";
 
+//The old one
 const useUser = () => {
   return useQuery({
     queryKey: ["me"],

--- a/src/hooks/useUsers.tsx
+++ b/src/hooks/useUsers.tsx
@@ -1,0 +1,24 @@
+import { useQuery } from "@tanstack/react-query";
+import { getUsers, getMe } from "@/api/users";
+import { getDoctors } from "@/api/doctors";
+
+export const useUsers = () => {
+  return useQuery({
+    queryKey: ["users"],
+    queryFn: getUsers,
+  });
+};
+
+export const useMe = () => {
+  return useQuery({
+    queryKey: ["me"],
+    queryFn: getMe,
+  });
+};
+
+export const useDoctors = () => {
+  return useQuery({
+    queryKey: ["doctors"],
+    queryFn: getDoctors,
+  });
+};

--- a/src/pages/Inventory/ItemFormPage.tsx
+++ b/src/pages/Inventory/ItemFormPage.tsx
@@ -1,10 +1,9 @@
-import { getItemById } from "@/api/inventories";
-import { getLocations } from "@/api/locations";
 import DialogButton from "@/components/button/DialogButton";
 import ItemForm from "@/components/forms/wrapper/ItemForm";
 import Header from "@/components/header/Header";
 import Loading from "@/components/loading/Loading";
-import { useQuery } from "@tanstack/react-query";
+import { useItem } from "@/hooks/useItems";
+import { useLocations } from "@/hooks/useLocations";
 import { useNavigate, useParams } from "react-router-dom";
 
 //used for both create and edit
@@ -15,20 +14,12 @@ const ItemFormPage = () => {
   const isEdit = Boolean(id);
 
   //tenstack
-  const { data: itemData, isLoading: item } = useQuery({
-    queryKey: ["item", id],
-    queryFn: () => getItemById(Number(id)),
-    enabled: Boolean(id),
-  });
-
+  const { data: itemData, isLoading: item } = useItem(id);
   const {
     data: locationData,
     isLoading: location,
     error: fetchError,
-  } = useQuery({
-    queryFn: getLocations,
-    queryKey: ["locations"],
-  });
+  } = useLocations();
 
   const isLoading = item || location;
 

--- a/src/pages/Inventory/ItemPage.tsx
+++ b/src/pages/Inventory/ItemPage.tsx
@@ -1,11 +1,12 @@
-import { deleteItemById, getItems } from "@/api/inventories";
-import { getLocations } from "@/api/locations";
+import { deleteItemById } from "@/api/inventories";
+import { useItems } from "@/hooks/useItems";
+import { useLocations } from "@/hooks/useLocations";
 import AlertBox from "@/components/alertBox/AlertBox";
 import DialogButton from "@/components/button/DialogButton";
 import ItemColumns from "@/components/columns/ItemColumns";
 import Header from "@/components/header/Header";
 import { DataTable } from "@/components/table/data-table";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { Plus } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
@@ -57,31 +58,19 @@ const ItemServicePage = () => {
 
   //TenStack
   //locations
-  const { data: locations, error: fetchLocationError } = useQuery({
-    queryFn: getLocations,
-    queryKey: ["locations"],
-  });
+  const { data: locations, error: fetchLocationError } = useLocations();
 
   //items
   const {
     data,
     isLoading,
     error: fetchItemError,
-  } = useQuery({
-    queryFn: () =>
-      getItems(
-        paginationState.pageIndex + 1,
-        paginationState.pageSize,
-        debouncedSearch,
-        columnFilters
-      ),
-    queryKey: [
-      "items",
-      paginationState.pageIndex,
-      debouncedSearch,
-      columnFilters,
-    ],
-  });
+  } = useItems(
+    paginationState.pageIndex + 1,
+    paginationState.pageSize,
+    debouncedSearch,
+    columnFilters
+  );
 
   const { mutate: deleteItemMutate, isPending: isDeleting } = useMutation({
     mutationFn: deleteItemById,

--- a/src/pages/expense/CategoryPage.tsx
+++ b/src/pages/expense/CategoryPage.tsx
@@ -1,5 +1,6 @@
-import { deleteCategoryById, getCategories } from "@/api/categories";
-import { getLocations } from "@/api/locations";
+import { deleteCategoryById } from "@/api/categories";
+import { useCategories } from "@/hooks/useCategories";
+import { useLocations } from "@/hooks/useLocations";
 import AlertBox from "@/components/alertBox/AlertBox";
 import DialogButton from "@/components/button/DialogButton";
 import CategoryColumns from "@/components/columns/CategoryColumns";
@@ -8,7 +9,7 @@ import Header from "@/components/header/Header";
 import Loading from "@/components/loading/Loading";
 import { DataTable } from "@/components/table/data-table";
 import { useAuth } from "@/hooks/useAuth";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import type { PaginationState } from "@tanstack/react-table";
 import { Plus } from "lucide-react";
 import { useEffect, useState } from "react";
@@ -35,19 +36,13 @@ const CategoryPage = () => {
     data: categories,
     isLoading: isFetchingCategories,
     error: fetchCategoriesError,
-  } = useQuery({
-    queryFn: getCategories,
-    queryKey: ["categories"],
-  });
+  } = useCategories();
 
   const {
     data: locations,
     isLoading: isFetchingLocations,
     error: fetchLocationsError,
-  } = useQuery({
-    queryFn: getLocations,
-    queryKey: ["locations"],
-  });
+  } = useLocations();
 
   const { mutate: deleteCategoryMutate, isPending: isDeleting } = useMutation({
     mutationFn: deleteCategoryById,

--- a/src/pages/expense/ExpensesPage.tsx
+++ b/src/pages/expense/ExpensesPage.tsx
@@ -1,6 +1,7 @@
-import { getCategories } from "@/api/categories";
-import { deleteExpenseById, getExpenses } from "@/api/expenses";
-import { getLocations } from "@/api/locations";
+import { deleteExpenseById } from "@/api/expenses";
+import { useCategories } from "@/hooks/useCategories";
+import { useExpenses } from "@/hooks/useExpenses";
+import { useLocations } from "@/hooks/useLocations";
 import AlertBox from "@/components/alertBox/AlertBox";
 import DialogButton from "@/components/button/DialogButton";
 import ExpensesColumns from "@/components/columns/ExpenseColumns";
@@ -9,7 +10,7 @@ import Header from "@/components/header/Header";
 import Loading from "@/components/loading/Loading";
 import { DataTable } from "@/components/table/data-table";
 import { useAuth } from "@/hooks/useAuth";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import type { PaginationState } from "@tanstack/react-table";
 import { Plus } from "lucide-react";
 import { useEffect, useState } from "react";
@@ -37,30 +38,21 @@ const ExpensesPage = () => {
     data: expenses,
     isLoading: isFetchingExpenses,
     error: fetchExpensesError,
-  } = useQuery({
-    queryFn: getExpenses,
-    queryKey: ["expenses"],
-  });
+  } = useExpenses();
 
   //location
   const {
     data: locations,
     isLoading: isFetchingLocations,
     error: fetchLocationsError,
-  } = useQuery({
-    queryFn: getLocations,
-    queryKey: ["locations"],
-  });
+  } = useLocations();
 
   //category
   const {
     data: categories,
     isLoading: isFetchingCategories,
     error: fetchCategoriesError,
-  } = useQuery({
-    queryFn: getCategories,
-    queryKey: ["categories"],
-  });
+  } = useCategories();
 
   const { mutate: deleteExpenseMutate, isPending: isDeleting } = useMutation({
     mutationFn: deleteExpenseById,

--- a/src/pages/invoice/InvoiceFormPage.tsx
+++ b/src/pages/invoice/InvoiceFormPage.tsx
@@ -1,10 +1,9 @@
-import { getInvoiceById } from "@/api/invoice";
-import { getLocations } from "@/api/locations";
 import DialogButton from "@/components/button/DialogButton";
 import InvoiceForm from "@/components/forms/wrapper/InvoiceForm";
 import Header from "@/components/header/Header";
 import Loading from "@/components/loading/Loading";
-import { useQuery } from "@tanstack/react-query";
+import { useInvoice } from "@/hooks/useInvoices";
+import { useLocations } from "@/hooks/useLocations";
 import { useNavigate, useParams } from "react-router-dom";
 
 //used for both create and edit
@@ -15,20 +14,12 @@ const InvoiceFormPage = () => {
   const isEdit = Boolean(id);
 
   //tenstack
-  const { data: invoiceData, isLoading: isFetchingInvoice } = useQuery({
-    queryKey: ["invoice", id],
-    queryFn: () => getInvoiceById(Number(id)),
-    enabled: Boolean(id),
-  });
-
+  const { data: invoiceData, isLoading: isFetchingInvoice } = useInvoice(id);
   const {
     data: locationData,
     isLoading: location,
     error: fetchError,
-  } = useQuery({
-    queryFn: getLocations,
-    queryKey: ["locations"],
-  });
+  } = useLocations();
 
   const isLoading = isFetchingInvoice || location;
 

--- a/src/pages/invoice/InvoicePage.tsx
+++ b/src/pages/invoice/InvoicePage.tsx
@@ -1,4 +1,5 @@
-import { deleteInvoiceById, getInvoices } from "@/api/invoice";
+import { deleteInvoiceById } from "@/api/invoice";
+import { useInvoices } from "@/hooks/useInvoices";
 import { deletePatientById } from "@/api/patients";
 import AlertBox from "@/components/alertBox/AlertBox";
 import DialogButton from "@/components/button/DialogButton";
@@ -10,7 +11,7 @@ import { useAuth } from "@/hooks/useAuth";
 import useDebounce from "@/hooks/useDebounce";
 import type { DateRange } from "@/types/TreatmentType";
 import { formatLocalDate } from "@/utils/formatDate";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import type { PaginationState } from "@tanstack/react-table";
 import { Plus } from "lucide-react";
 import { useEffect, useState } from "react";
@@ -60,28 +61,18 @@ const InvoicePage = () => {
     }));
   }, []);
 
-  //treatments
+  //invoices
   const {
     data,
     isLoading,
-    error: fetchTreatmentError,
-  } = useQuery({
-    queryFn: () =>
-      getInvoices(
-        paginationState.pageIndex + 1,
-        paginationState.pageSize,
-        debouncedSearch,
-        date.startDate ? formatLocalDate(date.startDate) : undefined,
-        date.endDate ? formatLocalDate(date.endDate) : undefined
-      ),
-    queryKey: [
-      "invoices",
-      paginationState.pageIndex,
-      debouncedSearch,
-      date.startDate,
-      date.endDate,
-    ],
-  });
+    error: fetchInvoiceError,
+  } = useInvoices(
+    paginationState.pageIndex + 1,
+    paginationState.pageSize,
+    debouncedSearch,
+    date.startDate ? formatLocalDate(date.startDate) : undefined,
+    date.endDate ? formatLocalDate(date.endDate) : undefined
+  );
 
   const { mutate: deleteInvoiceMutate, isPending: isDeleting } = useMutation({
     mutationFn: deleteInvoiceById,
@@ -95,10 +86,10 @@ const InvoicePage = () => {
   });
 
   useEffect(() => {
-    if (fetchTreatmentError) {
+    if (fetchInvoiceError) {
       setErrorOpen(true);
     }
-  }, [fetchTreatmentError]);
+  }, [fetchInvoiceError]);
 
   const columns = InvoiceColumns({
     onDelete: deletePatientById,
@@ -136,13 +127,16 @@ const InvoicePage = () => {
         setGlobalFilter={setGlobalFilter}
         serverSideSearch
         navigateTo="/dashboard/invoices"
+        filterByDate
+        date={date}
+        setDate={setDate}
       />
-      {fetchTreatmentError && (
+      {fetchInvoiceError && (
         <AlertBox
           open={errorOpen}
           onClose={() => setErrorOpen(false)}
           title="Error"
-          description={fetchTreatmentError.message}
+          description={fetchInvoiceError.message}
           mode={"error"}
         />
       )}

--- a/src/pages/patient/PatientDetailsPage.tsx
+++ b/src/pages/patient/PatientDetailsPage.tsx
@@ -1,5 +1,4 @@
-import { getPatientById } from "@/api/patients";
-import { useQuery } from "@tanstack/react-query";
+import { usePatient } from "@/hooks/usePatients";
 import { useParams } from "react-router-dom";
 import { useState } from "react";
 import Loading from "@/components/loading/Loading";
@@ -17,11 +16,7 @@ const PatientDetailsPage = () => {
     data: patient,
     isLoading: isFetchingPatient,
     error: fetchPatientError,
-  } = useQuery({
-    queryKey: ["patient", id],
-    queryFn: () => getPatientById(Number(id)),
-    enabled: Boolean(id),
-  });
+  } = usePatient(id);
 
   if (isFetchingPatient)
     return <Loading className="flex justify-center h-screen items-center" />;

--- a/src/pages/patient/PatientPage.tsx
+++ b/src/pages/patient/PatientPage.tsx
@@ -1,5 +1,6 @@
-import { getLocations } from "@/api/locations";
-import { deletePatientById, getPatients } from "@/api/patients";
+import { deletePatientById } from "@/api/patients";
+import { useLocations } from "@/hooks/useLocations";
+import { usePatients } from "@/hooks/usePatients";
 import AlertBox from "@/components/alertBox/AlertBox";
 import DialogButton from "@/components/button/DialogButton";
 import PatientColumns from "@/components/columns/PatientColumns";
@@ -8,7 +9,7 @@ import Header from "@/components/header/Header";
 import Loading from "@/components/loading/Loading";
 import { DataTable } from "@/components/table/data-table";
 import { useAuth } from "@/hooks/useAuth";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import type { PaginationState } from "@tanstack/react-table";
 import { Plus } from "lucide-react";
 import { useState } from "react";
@@ -35,19 +36,13 @@ const PatientPage = () => {
     data: patients,
     isLoading: isFetchingPatients,
     error: fetchPatientError,
-  } = useQuery({
-    queryFn: getPatients,
-    queryKey: ["patients"],
-  });
+  } = usePatients();
 
   const {
     data: locations,
     isLoading: isFetchingLocations,
     error: fetchLocationError,
-  } = useQuery({
-    queryFn: getLocations,
-    queryKey: ["locations"],
-  });
+  } = useLocations();
 
   const { mutate: deletePatientMutate, isPending: isDeleting } = useMutation({
     mutationFn: deletePatientById,

--- a/src/pages/service/ServicePage.tsx
+++ b/src/pages/service/ServicePage.tsx
@@ -1,4 +1,5 @@
-import { deleteServiceById, getServices } from "@/api/services";
+import { deleteServiceById } from "@/api/services";
+import { useServices } from "@/hooks/useServices";
 import AlertBox from "@/components/alertBox/AlertBox";
 import DialogButton from "@/components/button/DialogButton";
 import ServiceColumns from "@/components/columns/ServiceColumns";
@@ -7,7 +8,7 @@ import Header from "@/components/header/Header";
 import Loading from "@/components/loading/Loading";
 import { DataTable } from "@/components/table/data-table";
 import { useAuth } from "@/hooks/useAuth";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import type { PaginationState } from "@tanstack/react-table";
 import { Plus } from "lucide-react";
 import { useState } from "react";
@@ -34,10 +35,7 @@ const ServicePage = () => {
     data: services,
     isLoading,
     error: fetchServiceError,
-  } = useQuery({
-    queryFn: getServices,
-    queryKey: ["services"],
-  });
+  } = useServices();
 
   const { mutate: deleteServiceMutate, isPending: isDeleting } = useMutation({
     mutationFn: deleteServiceById,

--- a/src/pages/setting/LocationPage.tsx
+++ b/src/pages/setting/LocationPage.tsx
@@ -1,4 +1,5 @@
-import { deleteLocation, getLocations } from "@/api/locations";
+import { deleteLocation } from "@/api/locations";
+import { useLocations } from "@/hooks/useLocations";
 import AlertBox from "@/components/alertBox/AlertBox";
 import DialogButton from "@/components/button/DialogButton";
 import LocationForm from "@/components/forms/wrapper/LocationForm";
@@ -6,7 +7,7 @@ import Header from "@/components/header/Header";
 import Loading from "@/components/loading/Loading";
 import LocationColumns from "@/components/columns/LocationColumns";
 import { DataTable } from "@/components/table/data-table";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { Plus } from "lucide-react";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
@@ -29,10 +30,7 @@ const LocationPage = () => {
     data,
     isLoading,
     error: fetchError,
-  } = useQuery({
-    queryFn: getLocations,
-    queryKey: ["locations"],
-  });
+  } = useLocations();
 
   useEffect(() => {
     if (fetchError) {

--- a/src/pages/setting/RoleFormPage.tsx
+++ b/src/pages/setting/RoleFormPage.tsx
@@ -1,11 +1,9 @@
-import { getPermissions } from "@/api/permissions";
-import { getRoleById } from "@/api/roles";
+import { usePermissions, useRole } from "@/hooks/useRoles";
 import AlertBox from "@/components/alertBox/AlertBox";
 import DialogButton from "@/components/button/DialogButton";
 import RoleForm from "@/components/forms/wrapper/RoleForm";
 import Header from "@/components/header/Header";
 import Loading from "@/components/loading/Loading";
-import { useQuery } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 
@@ -22,20 +20,13 @@ const RoleFormPage = () => {
     data: role,
     isLoading: isFetchingRole,
     error: fetchRoleError,
-  } = useQuery({
-    queryKey: ["role", id],
-    queryFn: () => getRoleById(Number(id)),
-    enabled: isEdit,
-  });
+  } = useRole(id);
 
   const {
     data: permissions,
     isLoading: isFetchingPermissions,
     error: fetchPermissionError,
-  } = useQuery({
-    queryKey: ["permissions"],
-    queryFn: getPermissions,
-  });
+  } = usePermissions();
 
   const fetchError = fetchPermissionError || fetchRoleError;
   const isLoading = isFetchingPermissions || isFetchingRole;

--- a/src/pages/setting/RolePage.tsx
+++ b/src/pages/setting/RolePage.tsx
@@ -1,4 +1,5 @@
-import { deleteRoleById, getRoles } from "@/api/roles";
+import { deleteRoleById } from "@/api/roles";
+import { useRoles } from "@/hooks/useRoles";
 import AlertBox from "@/components/alertBox/AlertBox";
 import DialogButton from "@/components/button/DialogButton";
 import RoleColumns from "@/components/columns/RoleColumns";
@@ -6,7 +7,7 @@ import Header from "@/components/header/Header";
 import Loading from "@/components/loading/Loading";
 import { DataTable } from "@/components/table/data-table";
 import { useAuth } from "@/hooks/useAuth";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { Plus } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
@@ -31,10 +32,7 @@ const RolePage = () => {
     data: roles,
     isLoading: isFetchingRoles,
     error: fetchRoleError,
-  } = useQuery({
-    queryFn: getRoles,
-    queryKey: ["roles"],
-  });
+  } = useRoles();
 
   const { mutate: deleteRoleMutate, isPending: isDeleting } = useMutation({
     mutationFn: deleteRoleById,

--- a/src/pages/setting/UserPage.tsx
+++ b/src/pages/setting/UserPage.tsx
@@ -1,6 +1,7 @@
-import { getLocations } from "@/api/locations";
-import { getRoles } from "@/api/roles";
-import { deleteUserById, getUsers } from "@/api/users";
+import { deleteUserById } from "@/api/users";
+import { useLocations } from "@/hooks/useLocations";
+import { useRoles } from "@/hooks/useRoles";
+import { useUsers } from "@/hooks/useUsers";
 import AlertBox from "@/components/alertBox/AlertBox";
 import DialogButton from "@/components/button/DialogButton";
 import UserColumns from "@/components/columns/UserColumns";
@@ -10,7 +11,7 @@ import Loading from "@/components/loading/Loading";
 import { DataTable } from "@/components/table/data-table";
 import { useAuth } from "@/hooks/useAuth";
 import useLogout from "@/hooks/useLogout";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { Plus } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
@@ -37,30 +38,21 @@ const UserPage = () => {
     data: users,
     isLoading: isFetchingUsers,
     error: fetchUserError,
-  } = useQuery({
-    queryFn: getUsers,
-    queryKey: ["users"],
-  });
+  } = useUsers();
 
   //locations
   const {
     data: locations,
     isLoading: isFetchingLocations,
     error: fetchLocationError,
-  } = useQuery({
-    queryFn: getLocations,
-    queryKey: ["locations"],
-  });
+  } = useLocations();
 
   //roles
   const {
     data: roles,
     isLoading: isFetchingRoles,
     error: fetchRoleError,
-  } = useQuery({
-    queryFn: getRoles,
-    queryKey: ["roles"],
-  });
+  } = useRoles();
 
   const { mutate: deleteUserMutate, isPending: isDeleting } = useMutation({
     mutationFn: deleteUserById,

--- a/src/pages/treatment/TreatmentFormPage.tsx
+++ b/src/pages/treatment/TreatmentFormPage.tsx
@@ -1,21 +1,16 @@
-import { getDoctors } from "@/api/doctors";
-import { getPatients } from "@/api/patients";
-import { getTreatmentById } from "@/api/treatments";
 import TreatmentForm from "@/components/forms/wrapper/TreatmentForm";
 import Header from "@/components/header/Header";
 import Loading from "@/components/loading/Loading";
-import { useQuery } from "@tanstack/react-query";
+import { useDoctors } from "@/hooks/useDoctors";
+import { usePatients } from "@/hooks/usePatients";
+import { useTreatment } from "@/hooks/useTreatments";
 import { useParams } from "react-router-dom";
 
 const TreatmentFormPage = () => {
   const { id } = useParams();
   const isEdit = Boolean(id);
 
-  const { data: treatmentData, isLoading: isFetchingItem } = useQuery({
-    queryKey: ["treatment", id],
-    queryFn: () => getTreatmentById(Number(id)),
-    enabled: Boolean(id),
-  });
+  const { data: treatmentData, isLoading: isFetchingItem } = useTreatment(id);
 
   console.log("Fetching");
   console.log(treatmentData?.data.treatment);
@@ -24,19 +19,13 @@ const TreatmentFormPage = () => {
     data: patients,
     isLoading: isFetchingPatients,
     error: fetchPatientError,
-  } = useQuery({
-    queryFn: getPatients,
-    queryKey: ["patients"],
-  });
+  } = usePatients();
 
   const {
     data: doctors,
     isLoading: isFetchingDoctors,
     error: fetchDoctorError,
-  } = useQuery({
-    queryFn: getDoctors,
-    queryKey: ["doctors"],
-  });
+  } = useDoctors();
 
   const isLoading = isFetchingPatients || isFetchingDoctors || isFetchingItem;
 

--- a/src/pages/treatment/TreatmentPage.tsx
+++ b/src/pages/treatment/TreatmentPage.tsx
@@ -1,4 +1,5 @@
-import { deleteTreatmentById, getTreatments } from "@/api/treatments";
+import { deleteTreatmentById } from "@/api/treatments";
+import { useTreatments } from "@/hooks/useTreatments";
 import AlertBox from "@/components/alertBox/AlertBox";
 import DialogButton from "@/components/button/DialogButton";
 import TreatmentColumns from "@/components/columns/TreatmentColumns";
@@ -8,7 +9,7 @@ import { useAuth } from "@/hooks/useAuth";
 import useDebounce from "@/hooks/useDebounce";
 import type { DateRange } from "@/types/TreatmentType";
 import { formatLocalDate } from "@/utils/formatDate";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import type { PaginationState } from "@tanstack/react-table";
 import { useEffect, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
@@ -62,23 +63,13 @@ const TreatmentPage = () => {
     data,
     isLoading,
     error: fetchTreatmentError,
-  } = useQuery({
-    queryFn: () =>
-      getTreatments(
-        paginationState.pageIndex + 1,
-        paginationState.pageSize,
-        debouncedSearch,
-        date.startDate ? formatLocalDate(date.startDate) : undefined,
-        date.endDate ? formatLocalDate(date.endDate) : undefined
-      ),
-    queryKey: [
-      "treatments",
-      paginationState.pageIndex,
-      debouncedSearch,
-      date.startDate,
-      date.endDate,
-    ],
-  });
+  } = useTreatments(
+    paginationState.pageIndex + 1,
+    paginationState.pageSize,
+    debouncedSearch,
+    date.startDate ? formatLocalDate(date.startDate) : undefined,
+    date.endDate ? formatLocalDate(date.endDate) : undefined
+  );
 
   const { mutate: deleteTreatmentMutate, isPending: isDeleting } = useMutation({
     mutationFn: deleteTreatmentById,


### PR DESCRIPTION
This commit refactors the data fetching logic in various components and pages by introducing custom hooks. This change improves code reusability, maintainability, and separation of concerns.

- Replaced direct API calls within components with custom hooks (e.g., `useItems`, `useLocations`, `usePatients`).
- Created new custom hooks for various data entities (e.g., `useCategories`, `useDoctors`, `useExpenses`, `useInvoices`, `useItems`, `useLocations`, `usePatients`, `useRoles`, `useServices`, `useTreatments`, `useUsers`).
- Updated components to use these custom hooks for fetching data, simplifying the component logic and improving readability.
- Removed the old useUser hook and replaced it with useMe hook